### PR TITLE
Disables autofill

### DIFF
--- a/build.html
+++ b/build.html
@@ -6,7 +6,7 @@
     </div>
 
     <div class="fl-login-form">
-      <form class="form-horizontal">
+      <form class="form-horizontal" autocomplete="false">
         <div class="form-group clearfix ">
           <div class="col-sm-12 fl-email">
             <input type="email" class="form-control profile_email" name="Email" placeholder="Enter your email">

--- a/js/build.js
+++ b/js/build.js
@@ -184,10 +184,29 @@ $('[data-login-ds-id]').each(function() {
               _this.find('span').removeClass('hidden');
               _this.find('.loader').removeClass('show');
 
-              if (typeof data.loginAction !== "undefined" && !Fliplet.Env.get('disableSecurity')) {
-                Fliplet.Navigate.to(data.loginAction);
+              if (Fliplet.Env.get('disableSecurity')) {
+                return Fliplet.UI.Toast({
+                  type: 'regular',
+                  duration: false,
+                  tapToDismiss: false,
+                  title: 'Login successful',
+                  message: 'Note: You must enable app security via "Options > Enable app security for testing" to test any security features.',
+                  actions: [
+                    {
+                      label: 'OK',
+                      action: function () {
+                        Fliplet.UI.Toast.dismiss();
+                      }
+                    }
+                  ]
+                });
               }
 
+              if (typeof data.loginAction === 'undefined') {
+                return Fliplet.UI.Toast('Login successful');
+              } else {
+                return Fliplet.Navigate.to(data.loginAction);
+              }
             });
         }, function(error) {
           // Reset Login button

--- a/js/build.js
+++ b/js/build.js
@@ -144,6 +144,11 @@ $('[data-login-ds-id]').each(function() {
   function attachEventListeners() {
 
     $(containerSelector).on('click', '.btn-login', function() {
+      $(containerSelector).find('.fl-login-form form').trigger('submit');
+    });
+
+    $(containerSelector).on('submit', '.fl-login-form form', function(e) {
+      e.preventDefault();
       var _this = $(this);
       _this.parents('.form-btns').find('.login-error').addClass('hidden');
 


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/2705

* Disables autofill
* Allow login by submitting form instead of clicking on **login** button
* Adds Toast notification if security is disabled or if no login action is set

**No login action**

A minimal Toast UI is shown to inform user the login was successful. Though the app won't do anything else.

![image](https://user-images.githubusercontent.com/290733/41094937-4021efbe-6a50-11e8-8efd-1a968b3277e7.png)

**Security disabled**

A regular Toast UI is shown to the inform the uer the login was successful and that security must be enabled to perform any further testing on security features.

![image](https://user-images.githubusercontent.com/290733/41094970-537e91ac-6a50-11e8-9113-a0cb16e6bc81.png)
