### PR TITLE
Avoid icons from the login component from overlapping the dropdown menu

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -52,7 +52,7 @@ input.form-control {
   font-size: 22px;
   line-height: 24px;
   margin-top: -12px;
-  z-index: 10;
+  z-index: 9;
   border-right: 1px solid #337ab7;
   text-align: center;
   color: #337ab7;
@@ -74,7 +74,7 @@ input.form-control {
   font-size: 22px;
   line-height: 24px;
   margin-top: -12px;
-  z-index: 10;
+  z-index: 9;
   border-right: 1px solid #337ab7;
   text-align: center;
   color: #337ab7;


### PR DESCRIPTION
@squallstar @tonytlwu 
fixed Icons from "Login" component overlap
ref https://github.com/Fliplet/fliplet-studio/issues/4610
![Screen Recording 2019-08-01 at 04 25 PM](https://user-images.githubusercontent.com/52824216/62297240-89f3a780-b479-11e9-8328-d975d5ecc812.gif)
