### PR TITLE
Fixes incorrect error message in login component when used in Studio

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -218,7 +218,7 @@ $('[data-login-ds-id]').each(function() {
               duration: false,
               tapToDismiss: false,
               title: 'Login successful',
-              message: 'Note: You must enable app security via "Options > Enable app security for testing" to test any security features.',
+              message: 'To test security features in Fliplet Studio, go to "Change preview settings > Enable security" in the preview options on the right to enable security.',
               actions: [
                 {
                   label: 'OK',


### PR DESCRIPTION
@squallstar @tonytlwu 

**Fixed behavior:**
Updated warning message when logging into apps in Studio without the security option enabled. 

ref https://github.com/Fliplet/fliplet-studio/issues/4427

![issue4427](https://user-images.githubusercontent.com/53430352/62373965-993f2780-b543-11e9-8893-ea654bdf80f5.png)
