### PR TITLE
Loader size is now same in all operating systems

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -107,7 +107,9 @@ input.form-control {
 .loader:after {
   border-radius: 50%;
   width: 10em;
+  max-width: 21px;
   height: 10em;
+  max-height: 21px;
 }
 
 .loader {
@@ -115,10 +117,10 @@ input.form-control {
   font-size: 2px;
   position: relative;
   text-indent: -9999em;
-  border-top: 1.1em solid rgba(255, 255, 255, 0.2);
-  border-right: 1.1em solid rgba(255, 255, 255, 0.2);
-  border-bottom: 1.1em solid rgba(255, 255, 255, 0.2);
-  border-left: 1.1em solid #FFFFFF;
+  border-top: 5px solid rgba(255, 255, 255, 0.2);
+  border-right: 5px solid rgba(255, 255, 255, 0.2);
+  border-bottom: 5px solid rgba(255, 255, 255, 0.2);
+  border-left: 5px solid #FFFFFF;
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4808

## Description
Added max-height and max-width property.
Set border width to 5px.

## Screenshots/screencasts

Windows 10 Chrome
![windows 10 Chrome](https://user-images.githubusercontent.com/52824207/65515235-992a2b00-dee7-11e9-8c46-5ae5bddbcef4.png)

Windows IE11
![Windows 10 IE11](https://user-images.githubusercontent.com/52824207/65515236-992a2b00-dee7-11e9-87ad-ed922ca3b0d1.png)

Android 9 emulator
![Android 9 emulator](https://user-images.githubusercontent.com/52824207/65515237-99c2c180-dee7-11e9-900a-a5cd2dd38f8d.png)

Mac OS Safari
<img width="334" alt="Mac OS Safari" src="https://user-images.githubusercontent.com/52824207/65515238-99c2c180-dee7-11e9-87bd-c042307e27ea.png">

Mac OS Chrome
<img width="334" alt="Mac OS Chrome" src="https://user-images.githubusercontent.com/52824207/65515239-99c2c180-dee7-11e9-8c1c-f7097237c322.png">

## Backward compatibility
This change is fully backward compatible.