### PR TITLE
Saving selected data source after data source overlay close

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -249,7 +249,7 @@ function syncTempColumns(columnType) {
 
 Fliplet.Studio.onMessage(function(event) {
   if (event.data && event.data.event === 'overlay-close') {
-    reloadDataSource(event.data.data.dataSourceId);
+    reloadDataSource(event.data.data.dataSourceId || currentDataSource.id);
   }
 });
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5219

## Description
Saving selected data source after data source overlay close

## Screenshots/screencasts
https://share.getcloudapp.com/2NuBXqxL

## Backward compatibility

This change is fully backward compatible.

## Notes
This issue occurred because of the  `event.data.data.dataSourceId` whitch is empty.