### PR TITLE
Error message will be closed by timeout of 2 seconds

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -243,9 +243,24 @@ Fliplet.Widget.instance('login-ds', function(data) {
           _this.find('.btn-label').removeClass('hidden');
           _this.find('.loader').removeClass('show');
           _this.parents('.form-btns').find('.login-error').html('Your email or password don\'t match. Please try again.').removeClass('hidden');
-          Fliplet.UI.Toast.error(error, {
-            message: 'Login error'
-          });
+          Fliplet.UI.Toast({
+            type: 'minimal',
+            message: 'Login error',
+            duration: 2000,
+            actions: [
+              {
+                label: 'Detail',
+                action: function () {
+                  Fliplet.UI.Toast({
+                    type: 'minimal',
+                    message: error.responseJSON.message,
+                    duration: 2000
+                  }); // Initiating a new Toast notification will automatically dismiss all existing Toast notifications
+                  return false;
+                }
+              }
+            ]
+          })
         });
     });
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5787

## Description
The error message will be closed by a timeout of 2 seconds

## Screenshots/screencasts
https://share.getcloudapp.com/d5u0XoJ5

## Backward compatibility

This change is fully backward compatible.

## Notes
Changed Toast.error for usual Toast because with Toast.error close by timeout wasn't working even if I passed duration key to it