### PR TITLE
Sentry error fix

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -320,7 +320,7 @@ $dataSource.on('change', function onDataSourceListChange() {
   $('#select-pass-field').toggleClass('hidden', dsSelected);
 
   _.forEach(allDataSources, function(dataSource) {
-    if (dataSource.id === selectedValue && typeof dataSource.columns !== 'undefined') {
+    if (dataSource.id === selectedValue && dataSource.columns) {
       currentDataSource = dataSource;
       _.forEach(dataSource.columns, renderDataSourceColumn);
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6038

## Description
The issue occurred due to dataSource.columns being null, not undefined as checked before.

## Screenshots/screencasts
Error not occurring anymore.

## Backward compatibility
This change is fully backward compatible.

## Reviewers 
@upplabs-alex-levchenko @YaroslavOvdii 