### PR TITLE
ID-246 [Chore] Only show "Login" heading for old instances

### DIFF
--- a/build.html
+++ b/build.html
@@ -1,5 +1,5 @@
 <div data-login-ds-id="{{id}}" data-login-ds-uuid="{{uuid}}">
-  <h1 class="text-center">Login</h1>
+  {{#if heading}}<h1 class="text-center">{{heading}}</h1>{{/if}}
   <div class="fl-login-holder" ontouchstart="">
     <div class="fl-login-header">
       <p class="instruction">Enter your access details below</p>


### PR DESCRIPTION
This is to be released after https://github.com/Fliplet/fliplet-api/pull/4344 to ensure the migration adds the relevant attribute value to all existing instances.