### PR TITLE
OD-263 [Fix] Users can log in with an email witch have an upper case in it

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -143,6 +143,8 @@ function initDataSourceProvider(currentDataSourceId) {
           $dataColumnsPass.val(data.passColumn);
         }
 
+        currentDataSource = dataSource;
+
         $('#select-email-field').toggleClass('hidden', !dataSource.id);
         $('#select-pass-field').toggleClass('hidden', !dataSource.id);
       }


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-263

## Description
Users can log in with an email witch have an upper case in it

## Screenshots/screencasts
https://share.getcloudapp.com/OAuWwL70

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
This solution is working because we have a check for it and when the check is going threw we are adding a definition that we need at this [line](https://github.com/Fliplet/fliplet-widget-login-data-source/blob/master/js/interface.js#L224).