### PR TITLE
OD-292 [Fix] Users can unselect data source without any errors.

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -143,7 +143,7 @@ function initDataSourceProvider(currentDataSourceId) {
           $dataColumnsPass.val(data.passColumn);
         }
 
-        currentDataSource = dataSource;
+        currentDataSource = dataSource.id ? dataSource : null;
 
         $('#select-email-field').toggleClass('hidden', !dataSource.id);
         $('#select-pass-field').toggleClass('hidden', !dataSource.id);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-292

## Description
If the dataSource object does not have an id property that means that the user unselected the data source and the dataSource object now is { value: null }.
In that case, we should set the currentDataSource variable to 'null'.

## Screenshots/screencasts
https://share.getcloudapp.com/8LunoN27

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko