### PR TITLE
OD-789 [Fix] Fixed slide position during animation

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -173,22 +173,22 @@ input.form-control {
 .fl-restore-pass .state.past {
   -webkit-transform: translate3d(-105%, 0, 0);
   transform: translate3d(-105%, 0, 0);
-  -webkit-transition: all 0.25s ease;
-  transition: all 0.25s ease;
+  -webkit-transition: transform 0.25s ease, traopacitynsform 0.25s ease;
+  transition: transform 0.25s ease, traopacitynsform 0.25s ease;
 }
 
 .fl-restore-pass .state.present {
   opacity: 1;
   pointer-events: all;
-  -webkit-transition: all 0.25s ease;
-  transition: all 0.25s ease;
+  -webkit-transition: transform 0.25s ease, traopacitynsform 0.25s ease;
+  transition: transform 0.25s ease, traopacitynsform 0.25s ease;
 }
 
 .fl-restore-pass .state.future {
   -webkit-transform: translate3d(105%, 0, 0);
   transform: translate3d(105%, 0, 0);
-  -webkit-transition: all 0.25s ease;
-  transition: all 0.25s ease;
+  -webkit-transition: transform 0.25s ease, traopacitynsform 0.25s ease;
+  transition: transform 0.25s ease, traopacitynsform 0.25s ease;
   display: none;
 }
 


### PR DESCRIPTION
@romanyosyfiv

OD-789 https://weboo.atlassian.net/browse/OD-789

## Description
**Problem**: When the sliders switched, the slide position broke. This was because animation was applied to all styles of elements
**Solution**: Animation is used only for slide positioning and opacity

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko