### PR TITLE
ID-3354 [Chore] Ensure definition is updated when saving

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -116,6 +116,12 @@ function initDataSourceProvider(currentDataSourceId) {
     accessRules: []
   };
 
+  if (currentDataSourceId) {
+    Fliplet.DataSources.getById(currentDataSourceId).then(function(dataSource) {
+      currentDataSource = dataSource;
+    });
+  }
+
   dataSourceProvider = Fliplet.Widget.open('com.fliplet.data-source-provider', {
     selector: '#dataSourceProvider',
     data: dataSourceData,


### PR DESCRIPTION
This patch fixes an edge case where the data source definition isn't updated unless the data source selection is updated by the user (because of https://github.com/Fliplet/fliplet-widget-login-data-source/blob/master/js/interface.js#L233-L249)

With this change, the data source definition is correctly updated even when the selected data source hasn't been changed via the provider UI.

