### PR TITLE
PS-243 Remove auto translation from dynamic button name (Signup button)

### DIFF
--- a/build.html
+++ b/build.html
@@ -52,7 +52,7 @@
           {{#if hasSignupScreen}}
             <p>
               <button class="btn btn-secondary btn-signup focus-outline" type="button">
-                <span class="btn-label" data-translate="widgets.login.dataSource.login.signup">{{ signupButtonLabel }}</span>
+                <span class="btn-label">{{ signupButtonLabel }}</span>
               </button>
             </p>
           {{/if}}

--- a/translation.json
+++ b/translation.json
@@ -11,7 +11,6 @@
           "mismatch": "The details you entered don’t match our records. Please try again.",
           "action": "Log in",
           "forgotPassword": "Forgot your password?",
-          "signup": "Create account",
           "signupWarningBoldMessage": "Registration button seems to be hidden.",
           "signupWarningMessage": "Please ensure the registration button is visible. Until the registration button is restored the log in feature won't work."
         },


### PR DESCRIPTION
# What PR does
- Removes the translation instruction from the signup button label

# JIRA ticket
https://weboo.atlassian.net/browse/PS-243